### PR TITLE
Correct file name start_cifs.sh to start_samba.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
-COPY start_cifs.sh /opt/
+COPY start_samba.sh /opt/
 
 EXPOSE 137/udp 138/udp 139 445
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -57,7 +57,7 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
-COPY start_cifs.sh /opt/
+COPY start_samba.sh /opt/
 
 EXPOSE 137/udp 138/udp 139 445
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -57,7 +57,7 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
-COPY start_cifs.sh /opt/
+COPY start_samba.sh /opt/
 
 EXPOSE 137/udp 138/udp 139 445
 


### PR DESCRIPTION
File `start_cifs.sh` not exist, create this PR to correct file name `start_cifs.sh` to `start_samba.sh`

ref: [6530](https://github.com/longhorn/longhorn/issues/6530)

cc @derekbit 